### PR TITLE
Expose a service as resource

### DIFF
--- a/src/net40/Radical.Windows.Presentation/ComponentModel/IConventionsHandler.cs
+++ b/src/net40/Radical.Windows.Presentation/ComponentModel/IConventionsHandler.cs
@@ -298,12 +298,30 @@ namespace Topics.Radical.Windows.Presentation.ComponentModel
 		[IgnorePropertyInjectionAttribue]
 		Action<DependencyObject, Object> DefaultAttachViewToViewModel { get; }
 
-		/// <summary>
-		/// Gets the view of the given view model.
-		/// </summary>
-		/// <value>
-		/// The get view of view model handler.
-		/// </value>
+        /// <summary>
+        /// Gets or sets the generate service static resource key convention.
+        /// </summary>
+        /// <value>
+        /// The generate service static resource key convention.
+        /// </value>
+        [IgnorePropertyInjectionAttribue]
+        Func<Type, object> GenerateServiceStaticResourceKey { get; set; }
+
+        /// <summary>
+        /// Default: Gets the default generate service static resource key convention.
+        /// </summary>
+        /// <value>
+        /// The default generate service static resource key.
+        /// </value>
+        [IgnorePropertyInjectionAttribue]
+        Func<Type, object> DefaultGenerateServiceStaticResourceKey { get; }
+
+        /// <summary>
+        /// Gets the view of the given view model.
+        /// </summary>
+        /// <value>
+        /// The get view of view model handler.
+        /// </value>
         [IgnorePropertyInjectionAttribue]
         Func<Object, DependencyObject> GetViewOfViewModel { get; set; }
 

--- a/src/net40/Radical.Windows.Presentation/Radical.Windows.Presentation.csproj
+++ b/src/net40/Radical.Windows.Presentation/Radical.Windows.Presentation.csproj
@@ -155,6 +155,7 @@
     <AppDesigner Include="Properties\" />
     <Compile Include="Properties\XmlnsDefinitions.cs" />
     <Compile Include="ComponentModel\IRegionInjectionHandler.cs" />
+    <Compile Include="Services\ResourcesRegistrationHolder.cs" />
     <Compile Include="Services\ViewModelResolver.cs" />
     <Compile Include="Services\RegionInjectionHandler.cs" />
     <Compile Include="Services\Validation\AbstractValidationService.cs" />

--- a/src/net40/Radical.Windows.Presentation/Services/ConventionsHanlder.cs
+++ b/src/net40/Radical.Windows.Presentation/Services/ConventionsHanlder.cs
@@ -431,6 +431,9 @@ namespace Topics.Radical.Windows.Presentation.Services
             {
                 return this.DefaultShouldNotifyViewLoaded(view);
             };
+
+            DefaultGenerateServiceStaticResourceKey = type => type.Namespace + "." + type.Name;
+            GenerateServiceStaticResourceKey = type => DefaultGenerateServiceStaticResourceKey(type);
         }
 
         //Boolean TryFindWindowOrIClosableView( DependencyObject fe, out DependencyObject windowOrIClosableView )
@@ -820,5 +823,23 @@ namespace Topics.Radical.Windows.Presentation.Services
             get;
             set;
         }
+
+        /// <summary>
+        /// Gets or sets the generate service static resource key convention.
+        /// </summary>
+        /// <value>
+        /// The generate service static resource key convention.
+        /// </value>
+        [IgnorePropertyInjectionAttribue]
+        public Func<Type, object> GenerateServiceStaticResourceKey{ get; set; }
+
+        /// <summary>
+        /// Default: Gets or sets the generate service static resource key convention.
+        /// </summary>
+        /// <value>
+        /// The default generate service static resource key.
+        /// </value>
+        [IgnorePropertyInjectionAttribue]
+        public Func<Type, object> DefaultGenerateServiceStaticResourceKey{ get; }
     }
 }

--- a/src/net40/Radical.Windows.Presentation/Services/ResourcesRegistrationHolder.cs
+++ b/src/net40/Radical.Windows.Presentation/Services/ResourcesRegistrationHolder.cs
@@ -1,0 +1,12 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+
+namespace Topics.Radical.Windows.Presentation.Services
+{
+    class ResourcesRegistrationHolder
+    {
+        public IDictionary<Type, HashSet<Type>> Registrations { get; set; }
+    }
+}

--- a/src/net45/Radical.Windows.Presentation/Radical.Windows.Presentation.csproj
+++ b/src/net45/Radical.Windows.Presentation/Radical.Windows.Presentation.csproj
@@ -325,6 +325,9 @@
     <Compile Include="..\..\net40\Radical.Windows.Presentation\Services\RegionInjectionHandler.cs">
       <Link>Services\RegionInjectionHandler.cs</Link>
     </Compile>
+    <Compile Include="..\..\net40\Radical.Windows.Presentation\Services\ResourcesRegistrationHolder.cs">
+      <Link>Services\ResourcesRegistrationHolder.cs</Link>
+    </Compile>
     <Compile Include="..\..\net40\Radical.Windows.Presentation\Services\Validation\AbstractValidationService.cs">
       <Link>Services\Validation\AbstractValidationService.cs</Link>
     </Compile>


### PR DESCRIPTION
Connects to https://github.com/RadicalFx/Radical.Windows.Presentation/issues/49

This PR allows any registered component in the container to be exposed as a resource, services can be resources at the `Application` level:

```
bootstrapper.ExposeAsResource<TService>();
```

or at the `View` level

```
bootstrapper.ExposeAsResource<TService, TView>();
```

If services should be exposed as resources at the View level, resources are injected in the view at view resolution time by the `IViewResolver`.